### PR TITLE
Orb-H/issue6

### DIFF
--- a/src/lib/states/score.svelte.ts
+++ b/src/lib/states/score.svelte.ts
@@ -1,4 +1,4 @@
-import { getBest30, getBest30Average } from '$lib/utils/best';
+import { getBest40, getBest40Average } from '$lib/utils/best';
 import type { Song } from '$lib/types/song';
 import type { Score } from '$lib/types/score';
 import songsData from '$lib/data/songs.json';
@@ -63,11 +63,11 @@ const createInitialScores = (): Score[] => songs.map(createEmptyScore);
 
 class Scores {
 	scores: Score[] = $state([]);
-	best30Songs = $derived(getBest30(this.scores));
-	best30Average = $derived(getBest30Average(this.best30Songs));
+	best40Songs = $derived(getBest40(this.scores));
+	best40Average = $derived(getBest40Average(this.best40Songs));
 	targetRating = $derived(
-		scores.best30Songs.length > 0
-			? scores.best30Songs[scores.best30Songs.length - 1].rating + 0.03
+		scores.best40Songs.length > 0
+			? scores.best40Songs[scores.best40Songs.length - 1].rating + 0.04
 			: 0
 	);
 

--- a/src/lib/utils/best.ts
+++ b/src/lib/utils/best.ts
@@ -24,20 +24,17 @@ export function getBest40Average(charts: ChartInfo[]): number {
 	if (charts.length === 0) return 0;
 
 	const best10 = charts.slice(0, 10);
-	const better20 = charts.slice(10, 30);
+	const better10 = charts.slice(10, 20);
+	const last20 = charts.slice(20, 40);
 
-	// 충분한 곡이 없는 경우 처리
-	if (best10.length < 10) {
-		return best10.reduce((acc, chart) => acc + chart.rating, 0) / best10.length;
-	}
+	// TODO: 알려진 반올림 규칙이 이다면 반영
+	const best10rating = best10.reduce((acc, chart) => acc + chart.rating, 0);
+	const better10rating = better10.reduce((acc, chart) => acc + chart.rating, 0);
+	const last20rating = last20.reduce((acc, chart) => acc + chart.rating, 0);
 
-	const best10Rating = best10.reduce((acc, chart) => acc + chart.rating, 0) / 10;
-	const better20Rating =
-		better20.length > 0
-			? better20.reduce((acc, chart) => acc + chart.rating, 0) / Math.min(better20.length, 20)
-			: 0;
-
-	return best10Rating * 0.7 + better20Rating * 0.3;
+	const totalRating =
+		(best10rating * 0.6) / 10 + (better10rating * 0.2) / 10 + (last20rating * 0.2) / 20;
+	return totalRating;
 }
 
 export function getPotentialCharts(scores: Score[], targetRating: number): ChartInfo[] {

--- a/src/lib/utils/best.ts
+++ b/src/lib/utils/best.ts
@@ -1,7 +1,7 @@
 import type { ChartInfo } from '$lib/types/chart';
 import type { Score } from '$lib/types/score';
 
-export function getBest30(scores: Score[]): ChartInfo[] {
+export function getBest40(scores: Score[]): ChartInfo[] {
 	return scores
 		.flatMap((song): ChartInfo[] =>
 			song.charts
@@ -17,10 +17,10 @@ export function getBest30(scores: Score[]): ChartInfo[] {
 				}))
 		)
 		.sort((a, b) => b.rating - a.rating)
-		.slice(0, 30);
+		.slice(0, 40);
 }
 
-export function getBest30Average(charts: ChartInfo[]): number {
+export function getBest40Average(charts: ChartInfo[]): number {
 	if (charts.length === 0) return 0;
 
 	const best10 = charts.slice(0, 10);

--- a/src/lib/utils/rating.ts
+++ b/src/lib/utils/rating.ts
@@ -18,7 +18,7 @@ export function calculateSongRating(difficulty: number, score: number): number {
 	} else if (score < 1010000) {
 		rating = difficulty + 3.4 + (score - 1008000) / 10000;
 	} else {
-		rating = difficulty + 3.4 + (1010000 - 1008000) / 10000;
+		rating = difficulty + 3.7;
 	}
 
 	// If the player fails, ensure the rating doesn't exceed 6.0
@@ -34,8 +34,8 @@ export function calculateSongRating(difficulty: number, score: number): number {
 }
 
 export function calculateRequiredScore(difficulty: number, targetRating: number): number {
-	// 목표 레이팅이 난이도+3.6보다 높으면 달성 불가능
-	if (targetRating > difficulty + 3.6) {
+	// 목표 레이팅이 난이도+3.7보다 높으면 달성 불가능
+	if (targetRating > difficulty + 3.7) {
 		return -1; // 불가능한 목표
 	}
 
@@ -64,9 +64,12 @@ export function calculateRequiredScore(difficulty: number, targetRating: number)
 	} else if (targetRating <= difficulty + 3.4) {
 		// 1004000-1008000점 구간
 		requiredScore = 1004000 + (targetRating - (difficulty + 2.4)) * 4000;
-	} else {
+	} else if (targetRating < difficulty + 3.6) {
 		// 1008000-1010000점 구간
 		requiredScore = 1008000 + (targetRating - (difficulty + 3.4)) * 10000;
+	} else {
+		// 1010000점(이론치)
+		requiredScore = 1010000;
 	}
 
 	// 점수를 정수로 반올림

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -16,7 +16,7 @@
 		<div class="feature-grid">
 			<a href="/best" class="feature-card">
 				<h3>/best</h3>
-				<p>View and track your top 30 ratings with detailed performance statistics.</p>
+				<p>View and track your top 40 ratings with detailed performance statistics.</p>
 			</a>
 			<a href="/report" class="feature-card">
 				<h3>/report</h3>

--- a/src/routes/best/+page.svelte
+++ b/src/routes/best/+page.svelte
@@ -23,7 +23,7 @@
 			});
 
 			const link = document.createElement('a');
-			link.download = `best30_${new Date().toISOString().split('T')[0]}.png`;
+			link.download = `best40_${new Date().toISOString().split('T')[0]}.png`;
 			link.href = canvas.toDataURL('image/png');
 			link.click();
 		} catch (error) {
@@ -32,11 +32,11 @@
 	}
 </script>
 
-<div class="best30-container" bind:this={containerRef}>
+<div class="best40-container" bind:this={containerRef}>
 	<div class="header">
-		<h1>Best 30</h1>
+		<h1>Best 40</h1>
 		<div class="header-actions">
-			<span class="average">Average Rating: {scores.best30Average.toFixed(3)}</span>
+			<span class="average">Average Rating: {scores.best40Average.toFixed(3)}</span>
 			<button class="download-btn" on:click={downloadAsImage} bind:this={downloadBtn}>
 				<svg
 					xmlns="http://www.w3.org/2000/svg"
@@ -58,14 +58,14 @@
 	</div>
 
 	<div class="charts-grid">
-		{#each scores.best30Songs as chart, index}
+		{#each scores.best40Songs as chart, index}
 			<BestChartCard {chart} rank={index + 1} />
 		{/each}
 	</div>
 </div>
 
 <style>
-	.best30-container {
+	.best40-container {
 		max-width: 1200px;
 		margin: 0 auto;
 		padding: 2rem;

--- a/src/routes/report/+page.svelte
+++ b/src/routes/report/+page.svelte
@@ -21,7 +21,7 @@
 <div class="report-container">
 	<div class="header">
 		<div class="rating-info">
-			<span class="rating-label">Avg: {scores.best30Average.toFixed(3)}</span>
+			<span class="rating-label">Avg: {scores.best40Average.toFixed(3)}</span>
 			<span class="separator">|</span>
 			<span class="rating-label">Target: {scores.targetRating.toFixed(3)}</span>
 		</div>


### PR DESCRIPTION
## Background

* Issue: #6
* Resolves #6

위 이슈에 대하여 서치를 진행해보니, 여러 문서에서 B40 레이팅 계산식을 사용합니다. 아래와 같은 문서에서 모두 같은 계산식을 사용합니다:

* [디시인사이드](https://gall.dcinside.com/mgallery/board/view/?id=rotaeno&no=2297)
* [萌娘百科](https://zh.moegirl.org.cn/Rotaeno#Rating)
* [Fandom](https://rotaeno.fandom.com/wiki/Game_Mechanics#Rating)

기존 B30 계산식과 다른 점은 아래와 같습니다:

* 채보 별 레이팅 기준으로, 가중치가 아래와 같이 변경됩니다.
  ```
    0.6 * (1~10위 레이팅 합) / 10
  + 0.2 * (11~20위 레이팅 합) / 10
  + 0.2 * (21~40위 레이팅 합) / 20
  ```
* 이론치(1010000점)에 추가 레이팅 0.1이 추가됩니다. 따라서, 이론치의 채보에 대해서는 기존 `난이도 + 3.6`에서 `난이도 + 3.7`로 레이팅 값이 상향 조정됩니다.

## Changes

* 로직
  * 레이팅 계산식을 위와 같이 변경했습니다.
  * 레이팅 집계 채보의 수가 늘어남에 따라 목표 레이팅 값을 0.01 증가시켰습니다. (이 부분은 제가 이해를 아직 완벽히 하지 못했습니다)
  * 추천 채보의 목표 점수 값 조건을 이론치 추가 레이팅 조정에 맞게 변경했습니다.
* UI
  * `/best` 페이지에서 B30 대신 B40 데이터를 보여줍니다.

### 스크린샷

#### 레이팅 데이터

![KakaoTalk_20250406_203109942](https://github.com/user-attachments/assets/ac13db32-f3ce-4d5d-be50-447de5a27aa5)

#### 수정 전

![image](https://github.com/user-attachments/assets/7743380c-a7e1-4ad3-a019-195c9443e739)

#### 수정 후

![image](https://github.com/user-attachments/assets/e3a201c4-6c88-4a17-984b-b5609c24ed56)
