### PR TITLE
Orb-H/issue8

### DIFF
--- a/src/lib/utils/best.ts
+++ b/src/lib/utils/best.ts
@@ -46,8 +46,8 @@ export function getPotentialCharts(scores: Score[], targetRating: number): Chart
 					(chart) =>
 						// 현재 점수가 0이 아니고
 						chart.score !== 0 &&
-						// 난이도가 목표 레이팅 - 3.6 이상인 차트만 선택
-						chart.difficultyDecimal >= targetRating - 3.6
+						// 난이도가 목표 레이팅 - 3.7 이상인 차트만 선택
+						chart.difficultyDecimal >= targetRating - 3.7
 				)
 				.map((chart) => ({
 					songId: song.id,

--- a/src/lib/utils/best.ts
+++ b/src/lib/utils/best.ts
@@ -27,14 +27,15 @@ export function getBest40Average(charts: ChartInfo[]): number {
 	const better10 = charts.slice(10, 20);
 	const last20 = charts.slice(20, 40);
 
-	// TODO: 알려진 반올림 규칙이 이다면 반영
 	const best10rating = best10.reduce((acc, chart) => acc + chart.rating, 0);
 	const better10rating = better10.reduce((acc, chart) => acc + chart.rating, 0);
 	const last20rating = last20.reduce((acc, chart) => acc + chart.rating, 0);
 
 	const totalRating =
 		(best10rating * 0.6) / 10 + (better10rating * 0.2) / 10 + (last20rating * 0.2) / 20;
-	return totalRating;
+	// 최종 레이팅을 소수점 아래 4자리까지 반올림 후 소수점 아래 3자리가 되도록 버림(3자리까지만 출력).
+	// Ref: https://wiki.rotaeno.cn/Rating
+	return Math.floor(Math.round(totalRating * 10000.0) / 10.0) / 1000.0;
 }
 
 export function getPotentialCharts(scores: Score[], targetRating: number): ChartInfo[] {


### PR DESCRIPTION
## Background

- Issue: #8
- Resolves #8

위 이슈에 대한 해답을 찾기 위해 여러 사이트를 찾아본 결과, 아래와 같은 사이트에서 관련 정보를 얻을 수 있었습니다. (번역기와 LLM을 사용하여 해석하여 일부 차이가 있을 수 있습니다)

- https://zh.moegirl.org.cn/Rotaeno#Rating
  - 单谱Rating计算公式如下图（结果保留四位小数）: 각 채보 별 Rating 공식은 아래와 같음 (소수점 아래 4자리까지 반올림)
  - 其计算结果精确到小数点后三位。: 계산 결과의 정확도는 소수점 아래 3자리.
- https://wiki.rotaeno.cn/Rating
  - 其计算结果精确到小数点后四位，但在游戏中只显示小数点前三位的数值。: 계산 결과의 정확도는 소수점 아래 4자리이지만, 게임 상에 표기되는 값은 소수점 3자리까지만 표기.

위 정보를 취합하면, 대략적으로 소수점 아래 4자리까지 계산 후 3자리로 보이게 하는 방법을 사용하고 있는 것 같습니다. 다만 3자리로 보여주는 부분은 반올림인지, 버림인지 문서의 내용만을 이용해서는 확신할 수 없습니다.

이슈에서의 게임 데이터로 계산해본 결과, 레이팅 값이 17.570**8**...임에도 불구하고 17.570으로 표시되는 것으로 보아 우선은 버림으로 추측해볼 수 있습니다. 다만 이 또한 추측이므로 또 다른 상황에서 오차가 발생할 수도 있을 것 같네요...

## Changes

- getBest40Average에서 레이팅 계산 후, 소수점 아래 4자리까지 반올림 후 소수점 아래 3자리가 되도록 버린 값을 반환하도록 변경
- getPotentialCharts에서 필터 기준이 목표 레이팅 - 3.6이던 것을 3.7로 변경 (이 변경 내역은 #7 에서 놓쳤던 부분 같습니다)

### Example

이슈에서와 같은 데이터값을 사용했습니다.

| 실제 레이팅 (17.570) | 수정한 뒤 페이지 상의 레이팅 (17.571 → 17.570) |
|:-:|:-:|
|![KakaoTalk_20250416_011454754](https://github.com/user-attachments/assets/3bbe8338-5e1a-423e-9a7a-c8857217547e)|![image](https://github.com/user-attachments/assets/d6bed102-6ec8-460f-b15d-21127446d69a)|


## Consideration

- 가능하다면 merge하실 때 squash로 부탁드립니다 🙏 커밋 메시지를 너무 대충 썼네요ㅠ