### PR TITLE
Orb-H/issue11

### DIFF
--- a/src/lib/utils/best.ts
+++ b/src/lib/utils/best.ts
@@ -2,7 +2,7 @@ import type { ChartInfo } from '$lib/types/chart';
 import type { Score } from '$lib/types/score';
 
 export function getBest40(scores: Score[]): ChartInfo[] {
-	return scores
+	const sorted_charts = scores
 		.flatMap((song): ChartInfo[] =>
 			song.charts
 				.filter((chart) => (chart.rating ?? 0) > 0)
@@ -16,8 +16,22 @@ export function getBest40(scores: Score[]): ChartInfo[] {
 					rating: chart.rating ?? 0
 				}))
 		)
-		.sort((a, b) => b.rating - a.rating)
-		.slice(0, 40);
+		.sort((a, b) => b.rating - a.rating);
+
+	const best40: ChartInfo[] = [];
+	for (const chart of sorted_charts) {
+		if (best40.length >= 40) break;
+		// IV와 IV-α 중 레이팅이 높은 차트만 추가
+		if (
+			chart.difficultyLevel.startsWith('IV') &&
+			best40.some((c) => c.difficultyLevel.startsWith('IV') && c.songId == chart.songId, best40)
+		) {
+			continue;
+		}
+		best40.push(chart);
+	}
+
+	return best40;
 }
 
 export function getBest40Average(charts: ChartInfo[]): number {
@@ -33,9 +47,7 @@ export function getBest40Average(charts: ChartInfo[]): number {
 
 	const totalRating =
 		(best10rating * 0.6) / 10 + (better10rating * 0.2) / 10 + (last20rating * 0.2) / 20;
-	// 최종 레이팅을 소수점 아래 4자리까지 반올림 후 소수점 아래 3자리가 되도록 버림(3자리까지만 출력).
-	// Ref: https://wiki.rotaeno.cn/Rating
-	return Math.floor(Math.round(totalRating * 10000.0) / 10.0) / 1000.0;
+	return Math.floor(totalRating * 1000.0) / 1000.0;
 }
 
 export function getPotentialCharts(scores: Score[], targetRating: number): ChartInfo[] {

--- a/src/lib/utils/best.ts
+++ b/src/lib/utils/best.ts
@@ -22,9 +22,12 @@ export function getBest40(scores: Score[]): ChartInfo[] {
 	for (const chart of sorted_charts) {
 		if (best40.length >= 40) break;
 		// IV와 IV-α 중 레이팅이 높은 차트만 추가
+		// 이미 레이팅으로 정렬된 상태이므로, 먼저 추가된 IV 또는 IV-α 차트가 있는지만 확인하면 됨
 		if (
-			chart.difficultyLevel.startsWith('IV') &&
-			best40.some((c) => c.difficultyLevel.startsWith('IV') && c.songId == chart.songId, best40)
+			(chart.difficultyLevel === 'IV' &&
+				best40.some((c) => c.difficultyLevel === 'IV-α' && c.songId === chart.songId)) ||
+			(chart.difficultyLevel === 'IV-α' &&
+				best40.some((c) => c.difficultyLevel === 'IV' && c.songId === chart.songId))
 		) {
 			continue;
 		}

--- a/src/lib/utils/rating.ts
+++ b/src/lib/utils/rating.ts
@@ -16,7 +16,7 @@ export function calculateSongRating(difficulty: number, score: number): number {
 	} else if (score < 1008000) {
 		rating = difficulty + 2.4 + (score - 1004000) / 4000;
 	} else if (score < 1010000) {
-		rating = difficulty + 3.4 + (score - 1008000) / 10000;
+		rating = difficulty + 3.4 + (score - 1008000) / 9995;
 	} else {
 		rating = difficulty + 3.7;
 	}


### PR DESCRIPTION
## Background

- Issue: #11
- Resolves #11

위 이슈에서 언급한 내용대로 게임 소스 코드로부터 로직을 추출하였고, 이를 레이팅 계산식에 적용하는 PR입니다. 자세한 로직은 https://github.com/Orb-H/rotaeno-rating 에서 확인하실 수 있습니다.

## Changes

- 1008000~1009999 점수 구간의 계수 변경 ($\frac{1}{10000}$ → $\frac{1}{9995}$)
- 레이팅 기준으로 정렬 후, 같은 곡의 `IV`와 `IV-α`가 동시에 적용되지 않도록 변경
- 최종 레이팅 계산 후 소수점 세 자리 미만은 버리도록 변경

### Example

|이전 (17.585)|현재 (17.586)|
|:-:|:-:|
|![Image](https://github.com/user-attachments/assets/becdcb7e-4ca9-4dd6-b664-9ac3838b0411)|![image](https://github.com/user-attachments/assets/f1215858-44c6-4e71-9471-6955140e8031)|

이슈에서와 같은 데이터입니다. 세부 값을 비교해보면, 계수의 변경으로 인해 GALACTIC WARZONE과 MVURBD의 표시된 레이팅 값이 0.001씩 오른 것을 확인할 수 있고, 최종 레이팅도 0.001 증가하여 게임 내 표시되는 값과 같은 값임을 확인할 수 있습니다.