### PR TITLE
Dodok8/issue10

### DIFF
--- a/src/routes/backup/+page.svelte
+++ b/src/routes/backup/+page.svelte
@@ -61,6 +61,7 @@
 	async function downloadFromCloud() {
 		try {
 			await driveService?.requestAuth();
+			await driveService?.initializeBackup();
 			const jsonString = await driveService?.downloadBackup();
 			const jsonData = JSON.parse(jsonString || '');
 			scores.load(jsonData);
@@ -80,6 +81,7 @@
 
 		try {
 			await driveService?.requestAuth();
+			await driveService?.initializeBackup();
 			await driveService?.eraseBackup();
 			alert('Successfully deleted backup from Google Drive!');
 		} catch (error) {

--- a/src/routes/backup/+page.svelte
+++ b/src/routes/backup/+page.svelte
@@ -6,7 +6,6 @@
 
 	$effect(() => {
 		if (ready[0] && ready[1]) {
-			console.log("hi")
 			driveService.initialize();
 		}
 	});

--- a/src/routes/backup/drive.svelte.ts
+++ b/src/routes/backup/drive.svelte.ts
@@ -94,9 +94,6 @@ class DriveService {
 
 	async uploadBackup(content: string): Promise<void> {
 		try {
-			if (!this.backupFolderId) {
-				await this.initializeBackup();
-			}
 
 			// Create form data for multipart upload
 			const metadata = new Blob(


### PR DESCRIPTION
## Background

- Issue: #10
- Resolves #10

위 이슈에서 언급해 주신대로 파일 id 를 찾는 초기화 로직이 업로드 하는 경우에만 존재하고 있어서 오류가 발생하고 있었습니다.

## Changes

- `uploadBackup`에서 중복되는 `initializeFileId` 호출 제거, `+pages.svelte,ts`에서만 호출하도록 변경
- `downloadBackup`과 `eraseBackup`을 사용하는 함수에 `initializeFileId` 호출 추가
- 현재 구글 토큰 유무를 파악해서 토큰이 존재할 경우 인증창을 생략하도록 변경